### PR TITLE
Fixed #96

### DIFF
--- a/src/main/java/net/liukrast/eg/content/logistics/board/StringPanelBehaviour.java
+++ b/src/main/java/net/liukrast/eg/content/logistics/board/StringPanelBehaviour.java
@@ -116,7 +116,7 @@ public class StringPanelBehaviour extends AbstractPanelBehaviour {
             try {
                 Pattern pattern = Pattern.compile(regex);
                 res = pattern.matcher(res).replaceAll(replacement);
-            } catch (PatternSyntaxException e) {
+            } catch (PatternSyntaxException | IndexOutOfBoundsException | IllegalArgumentException e) {
                 res = "RegexError";
             }
         }


### PR DESCRIPTION
out of range escape sequences now return "RegexError" instead of crashing, same thing for incomplete escape sequences caused by a trailing "\"